### PR TITLE
Fix to deploy on Restack Cloud

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,23 @@
+FROM python:3.12-slim
 
-# Use the latest official Python runtime in slim variant
-FROM python:slim
-
-# Set the working directory in the container
 WORKDIR /app
 
-# Copy the requirements file into the container
-COPY requirements.txt .
+RUN apt-get update && apt-get install -y nginx
 
-# Install Python dependencies
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install poetry
 
-# Copy the current directory contents into the container at /app
+COPY pyproject.toml ./
+
 COPY . .
 
-# Make port 80 available to the world outside this container
+# Configure poetry to not create virtual environment
+RUN poetry config virtualenvs.create false
+
+# Install dependencies
+RUN poetry install --no-dev --no-interaction --no-ansi
+
+# Expose port 80
 EXPOSE 80
 
-# Run the application
-CMD ["python", "main.py"]
-
+# Start Poetry
+CMD poetry run services

--- a/restack_up.py
+++ b/restack_up.py
@@ -3,17 +3,9 @@ from restack_sdk_cloud import RestackCloud
 from dotenv import load_dotenv
 load_dotenv(override=True)
 
-print(f"GIT_URL: {os.getenv('GIT_URL')}")
-print(f"GIT_BRANCH: {os.getenv('GIT_BRANCH')}")
-
 async def main():
     # Initialize the RestackCloud client with the SDK token from environment variables
     restack_cloud_client = RestackCloud(os.getenv('RESTACK_CLOUD_TOKEN'))
-    git_url = os.getenv('GIT_URL', 'default_git_url')
-    git_branch = os.getenv('GIT_BRANCH', 'default_git_branch')
-    print("git_url: ", git_url)
-    print("git_branch: ", git_branch)
-
 
     engine = {
         'name': 'restack_engine', # IMPORTANT: This must match the name of the engine in the Restack Cloud console.
@@ -42,21 +34,15 @@ async def main():
           {
               'name': 'RESTACK_ENGINE_API_KEY',
               'value': os.getenv('RESTACK_ENGINE_API_KEY'),
-          },
-          {'name': 'gitUrl', 'value': os.getenv('GIT_URL')},
-          {'name': 'gitBranch', 'value': os.getenv('GIT_BRANCH')}
+          } 
         ],
-        'gitUrl': os.getenv('GIT_URL'),
-        'gitBranch': os.getenv('GIT_BRANCH'),
     }
 
     # Define the application configuration
     app = {
-        'name': 'defense_quickstart',
-        'dockerFilePath': '/examples/defense_quickstart/Dockerfile',
-        'dockerBuildContext': './examples/defense_quickstart/',
-        'gitUrl': git_url,
-        'gitBranch': git_branch,
+        'name': 'get_started',
+        'dockerFilePath': 'Dockerfile',
+        'dockerBuildContext': '.',
         'environmentVariables': [
             {
                 'name': 'RESTACK_ENGINE_ID',
@@ -70,15 +56,7 @@ async def main():
                 'name': 'RESTACK_ENGINE_API_KEY',
                 'value': os.getenv('RESTACK_ENGINE_API_KEY'),
             },
-            {
-                'name': 'OPENBABYLON_API_URL',
-                'value': os.getenv('OPENBABYLON_API_URL', ''),
-            },
-            {'name': 'gitUrl', 'value': os.getenv('GIT_URL')},
-            {'name': 'gitBranch', 'value': os.getenv('GIT_BRANCH')}
         ],
-    'gitUrl': os.getenv('GIT_URL'),
-    'gitBranch': os.getenv('GIT_BRANCH'),
     }
 
     # Configure the stack with the applications

--- a/schedule_calendar.py
+++ b/schedule_calendar.py
@@ -1,11 +1,8 @@
 import asyncio
 import time
-from restack_ai import Restack
-from restack_ai.restack import ScheduleSpec, ScheduleCalendarSpec, ScheduleRange
+from src.client import client
 
 async def main():
-
-    client = Restack()
 
     workflow_id = f"{int(time.time() * 1000)}-GreetingWorkflow"
     await client.schedule_workflow(

--- a/schedule_interval.py
+++ b/schedule_interval.py
@@ -1,12 +1,10 @@
 import asyncio
 import time
-from restack_ai import Restack
 from restack_ai.restack import ScheduleSpec, ScheduleIntervalSpec
 from datetime import timedelta
+from src.client import client
 
 async def main():
-
-    client = Restack()
 
     workflow_id = f"{int(time.time() * 1000)}-GreetingWorkflow"
     await client.schedule_workflow(

--- a/schedule_workflow.py
+++ b/schedule_workflow.py
@@ -1,10 +1,8 @@
 import asyncio
 import time
-from restack_ai import Restack
+from src.client import client
 
 async def main():
-
-    client = Restack()
 
     workflow_id = f"{int(time.time() * 1000)}-GreetingWorkflow"
     run_id = await client.schedule_workflow(
@@ -21,6 +19,6 @@ async def main():
 
 def run_schedule_workflow():
     asyncio.run(main())
-
+    
 if __name__ == "__main__":
     run_schedule_workflow()

--- a/src/client.py
+++ b/src/client.py
@@ -1,6 +1,9 @@
 import os
 from restack_ai import Restack
+from restack_ai.restack import CloudConnectionOptions
 from dotenv import load_dotenv
+
+load_dotenv()
 
 connection_options = CloudConnectionOptions(
     engine_id=os.getenv('RESTACK_ENGINE_ID'),

--- a/src/client.py
+++ b/src/client.py
@@ -1,4 +1,11 @@
 import os
 from restack_ai import Restack
+from dotenv import load_dotenv
 
-client = Restack()
+connection_options = CloudConnectionOptions(
+    engine_id=os.getenv('RESTACK_ENGINE_ID'),
+    address=os.getenv('RESTACK_ENGINE_ADDRESS'),
+    api_key=os.getenv('RESTACK_ENGINE_API_KEY')
+)
+
+client = Restack(connection_options)


### PR DESCRIPTION
1. Set in .env your environement variables
2. Run 'poetry env use 3.12', 'poetry shell' and 'python restack_up.py'
3. Connect repository with Github app
4. Confirm stack plan in terminal
5. After engine and services have been deployed to cloud, run from local in virtual env 'poetry run schedule'. Ensure environment variables are loaded in the client.

![image](https://github.com/user-attachments/assets/76cea264-4b44-4fe1-83c2-a26a44e9530c)
